### PR TITLE
Configure Dokka: suppress internal packages, disable configuration cache

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,5 +25,26 @@ allprojects {
     val excludedModules = listOf("composeApp", "example")
     if (name !in excludedModules) {
         apply(plugin = "org.jetbrains.dokka")
+
+        tasks.withType<org.jetbrains.dokka.gradle.DokkaTaskPartial>().configureEach {
+            dokkaSourceSets.configureEach {
+                perPackageOption {
+                    matchingRegex.set(".*\\.internal.*")
+                    suppress.set(true)
+                }
+            }
+        }
     }
+}
+
+tasks.withType<org.jetbrains.dokka.gradle.DokkaTask>().configureEach {
+    notCompatibleWithConfigurationCache("Dokka tasks are not compatible with configuration cache")
+}
+
+tasks.withType<org.jetbrains.dokka.gradle.DokkaTaskPartial>().configureEach {
+    notCompatibleWithConfigurationCache("Dokka tasks are not compatible with configuration cache")
+}
+
+tasks.withType<org.jetbrains.dokka.gradle.DokkaMultiModuleTask>().configureEach {
+    notCompatibleWithConfigurationCache("Dokka tasks are not compatible with configuration cache")
 }


### PR DESCRIPTION
- Add per-package suppression for internal packages in DokkaTaskPartial
- Mark Dokka, DokkaPartial, and DokkaMultiModule tasks as not compatible with configuration cache