### PR TITLE
Refactor URL opening and improve iOS window detection

### DIFF
--- a/adapty/build.gradle.kts
+++ b/adapty/build.gradle.kts
@@ -84,7 +84,6 @@ kotlin {
 
         val androidMain by getting {
             dependencies {
-                implementation(libs.androidx.browser)
                 implementation(libs.androidx.startup.runtime)
                 implementation(project.dependencies.platform(libs.adapty.bom))
                 implementation(libs.adapty.android.sdk)

--- a/adapty/src/androidMain/kotlin/com/adapty/kmp/Platform.android.kt
+++ b/adapty/src/androidMain/kotlin/com/adapty/kmp/Platform.android.kt
@@ -1,28 +1,20 @@
 package com.adapty.kmp
 
-import android.content.Intent
-import android.net.Uri
-import androidx.browser.customtabs.CustomTabsIntent
+import com.adapty.internal.crossplatform.CrossplatformHelper
 import com.adapty.kmp.internal.plugin.AdaptyPlugin
 import com.adapty.kmp.internal.plugin.AdaptyPluginImpl
 import com.adapty.kmp.models.AdaptyWebPresentation
+import com.adapty.models.AdaptyWebPresentation as AdaptyNativeSdkWebPresentation
 
 
 internal actual val adaptyPlugin: AdaptyPlugin by lazy { AdaptyPluginImpl() }
 internal actual val isAndroidPlatform: Boolean get() = true
 internal actual fun openUrl(url: String, openIn: AdaptyWebPresentation) {
-    val uri = runCatching { Uri.parse(url) }.getOrNull() ?: return
-    when (openIn) {
-        AdaptyWebPresentation.EXTERNAL_BROWSER -> {
-            val intent = Intent(Intent.ACTION_VIEW, uri)
-            intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-            applicationContext?.startActivity(intent)
+    CrossplatformHelper.shared.openUrl(
+        url = url,
+        presentation = when(openIn){
+            AdaptyWebPresentation.EXTERNAL_BROWSER -> AdaptyNativeSdkWebPresentation.ExternalBrowser
+            AdaptyWebPresentation.IN_APP_BROWSER -> AdaptyNativeSdkWebPresentation. InAppBrowser
         }
-        AdaptyWebPresentation.IN_APP_BROWSER -> {
-            val context = applicationContext ?: return
-            val customTabsIntent = CustomTabsIntent.Builder().build()
-            customTabsIntent.intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-            customTabsIntent.launchUrl(context, uri)
-        }
-    }
+    )
 }

--- a/adapty/src/iosMain/kotlin/com/adapty/kmp/Platform.ios.kt
+++ b/adapty/src/iosMain/kotlin/com/adapty/kmp/Platform.ios.kt
@@ -6,7 +6,10 @@ import com.adapty.kmp.models.AdaptyWebPresentation
 import platform.Foundation.NSURL
 import platform.SafariServices.SFSafariViewController
 import platform.UIKit.UIApplication
+import platform.UIKit.UISceneActivationStateForegroundActive
 import platform.UIKit.UIViewController
+import platform.UIKit.UIWindow
+import platform.UIKit.UIWindowScene
 
 internal actual val adaptyPlugin: AdaptyPlugin by lazy { AdaptyPluginImpl() }
 internal actual val isAndroidPlatform: Boolean get() = false
@@ -30,8 +33,23 @@ internal actual fun openUrl(url: String, openIn: AdaptyWebPresentation) {
 }
 
 private fun findTopViewController(): UIViewController? {
-    val rootVC = UIApplication.sharedApplication.keyWindow?.rootViewController ?: return null
+    val rootVC = findKeyWindow()?.rootViewController ?: return null
     return findTopPresented(rootVC)
+}
+
+private fun findKeyWindow(): UIWindow? {
+    val foregroundScenes = UIApplication.sharedApplication.connectedScenes
+        .filterIsInstance<UIWindowScene>()
+        .filter { it.activationState == UISceneActivationStateForegroundActive }
+        .ifEmpty {
+            UIApplication.sharedApplication.connectedScenes.filterIsInstance<UIWindowScene>()
+        }
+
+    for (scene in foregroundScenes) {
+        val windows = scene.windows.filterIsInstance<UIWindow>()
+        windows.firstOrNull { it.isKeyWindow() }?.let { return it }
+    }
+    return foregroundScenes.firstOrNull()?.windows?.filterIsInstance<UIWindow>()?.firstOrNull()
 }
 
 private fun findTopPresented(controller: UIViewController): UIViewController {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,7 +14,6 @@ kotlin = "2.2.21"
 kotlinx-binary-validator = "0.18.1"
 kotlinx-coroutine = "1.10.2"
 mavenPublish = "0.34.0"
-androidx-browser = "1.8.0"
 androidx-startup-runtime = "1.2.0"
 kotlinx-json-serialization = "1.9.0"
 kotlinx-datetime = "0.7.1"
@@ -28,7 +27,6 @@ androidx-foundation = { module = "androidx.compose.foundation:foundation" }
 androidx-lifecycle-viewmodel-compose = { group = "org.jetbrains.androidx.lifecycle", name = "lifecycle-viewmodel-compose", version.ref = "androidx-lifecycle" }
 androidx-lifecycle-runtime-compose = { group = "org.jetbrains.androidx.lifecycle", name = "lifecycle-runtime-compose", version.ref = "androidx-lifecycle" }
 androidx-material3 = { module = "androidx.compose.material3:material3" }
-androidx-browser = { module = "androidx.browser:browser", version.ref = "androidx-browser" }
 androidx-startup-runtime = { module = "androidx.startup:startup-runtime", version.ref = "androidx-startup-runtime" }
 
 adapty-bom = { module = "io.adapty:adapty-bom", version.ref = "adapty-bom" }


### PR DESCRIPTION
* Update Android URL opening logic to use `CrossplatformHelper` from the native SDK.
* Improve iOS key window detection to support `UIWindowScene` and modern scene-based architectures.
* Remove unused `androidx.browser` dependency from Android.