### PR TITLE
Fix log level handling and strip debug info from iOS bridge

### DIFF
--- a/adapty/build.gradle.kts
+++ b/adapty/build.gradle.kts
@@ -49,7 +49,7 @@ kotlin {
             else -> error("Unsupported target ${iosTarget.konanTarget}")
         }
         val derivedDataBuildDir = "$rootDir/adapty-swift-bridge/build/Build/Products"
-        val dedupTaskName = "dedup${platform.capitalize()}"
+        val dedupTaskName = "stripDebugInfo${platform.replaceFirstChar { it.uppercase() }}"
 
         iosTarget.compilations {
             val main by getting {
@@ -103,8 +103,9 @@ kotlin {
 val shouldForceIosRebuild: Boolean =
     project.findProperty("shouldForceIosRebuild")?.toString()?.toBooleanStrictOrNull() ?: false
 listOf("iphoneos", "iphonesimulator").forEach { sdk ->
-    tasks.create<Exec>("build${sdk.capitalize()}") {
+    tasks.register<Exec>("build${sdk.replaceFirstChar { it.uppercase() }}") {
         group = "build"
+        description = "Builds libAdaptySwiftBridge.a for $sdk via xcodebuild (Release)."
 
         commandLine(
             "xcodebuild",
@@ -139,13 +140,21 @@ listOf("iphoneos", "iphonesimulator").forEach { sdk ->
 // Dedup duplicate .o members in static libraries (GitHub issue #19)
 val dedupScript = "$rootDir/scripts/dedup_static_lib.sh"
 listOf("iphoneos", "iphonesimulator").forEach { sdk ->
-    tasks.register<Exec>("dedup${sdk.capitalize()}") {
+    val lib = "$rootDir/adapty-swift-bridge/build/Build/Products/Release-$sdk/libAdaptySwiftBridge.a"
+    tasks.register<Exec>("dedup${sdk.replaceFirstChar { it.uppercase() }}") {
         group = "build"
-        dependsOn("build${sdk.capitalize()}")
-        commandLine(
-            "bash", dedupScript,
-            "$rootDir/adapty-swift-bridge/build/Build/Products/Release-$sdk/libAdaptySwiftBridge.a"
-        )
+        description = "Removes duplicate .o members from the $sdk libAdaptySwiftBridge.a (issue #19)."
+        dependsOn("build${sdk.replaceFirstChar { it.uppercase() }}")
+        commandLine("bash", dedupScript, lib)
+        workingDir(rootDir)
+    }
+    // Runs after dedup and gates the cinterop step below, so the .a packaged into the klib is the
+    // stripped one (Github issue #34).
+    tasks.register<Exec>("stripDebugInfo${sdk.replaceFirstChar { it.uppercase() }}") {
+        group = "build"
+        description = "Strips debug info from the $sdk libAdaptySwiftBridge.a (issue #34)."
+        dependsOn("dedup${sdk.replaceFirstChar { it.uppercase() }}")
+        commandLine("strip", "-S", lib)
         workingDir(rootDir)
     }
 }

--- a/adapty/src/commonMain/kotlin/com/adapty/kmp/internal/AdaptyImpl.kt
+++ b/adapty/src/commonMain/kotlin/com/adapty/kmp/internal/AdaptyImpl.kt
@@ -101,6 +101,7 @@ internal class AdaptyImpl(
 
 
     override suspend fun activate(configuration: AdaptyConfig): AdaptyResult<Unit> {
+        configuration.logLevel?.let { applyLogLevel(it) }
         adaptyPlugin.initialize()
         return adaptyPlugin.awaitExecute<AdaptyConfigurationRequest, Boolean>(
             method = AdaptyPluginMethod.ACTIVATE,
@@ -246,10 +247,7 @@ internal class AdaptyImpl(
     }
 
     override fun setLogLevel(logLevel: AdaptyLogLevel) {
-        logger = when (logLevel) {
-            AdaptyLogLevel.DEBUG, AdaptyLogLevel.VERBOSE, AdaptyLogLevel.INFO -> ConsoleLogger
-            else -> EmptyLogger
-        }
+        applyLogLevel(logLevel)
 
         adaptyPlugin.execute<AdaptySetLogLevelRequest, Unit>(
             method = AdaptyPluginMethod.SET_LOG_LEVEL,

--- a/adapty/src/commonMain/kotlin/com/adapty/kmp/internal/AdaptyLogger.kt
+++ b/adapty/src/commonMain/kotlin/com/adapty/kmp/internal/AdaptyLogger.kt
@@ -2,6 +2,7 @@ package com.adapty.kmp.internal
 
 import com.adapty.kmp.isAndroidPlatform
 import com.adapty.kmp.models.AdaptyConfig
+import com.adapty.kmp.models.AdaptyLogLevel
 
 internal fun interface AdaptyLogger {
     fun log(message: String)
@@ -20,4 +21,15 @@ internal object ConsoleLogger : AdaptyLogger {
     }
 }
 
-internal var logger: AdaptyLogger = ConsoleLogger
+internal var logger: AdaptyLogger = EmptyLogger
+
+/**
+ * Selects the logger for [level]: console output at VERBOSE/DEBUG, silent otherwise. Called from
+ * both `activate` (so the level from [AdaptyConfig] applies) and `setLogLevel`.
+ */
+internal fun applyLogLevel(level: AdaptyLogLevel) {
+    logger = when (level) {
+        AdaptyLogLevel.VERBOSE, AdaptyLogLevel.DEBUG -> ConsoleLogger
+        else -> EmptyLogger
+    }
+}


### PR DESCRIPTION
Fixes two open issues.

- #35 — `AdaptyConfig.withLogLevel(...)` now applies to the KMP logger at `activate()`; previously only `setLogLevel()` did, so payloads (incl. profile data) logged regardless. The KMP layer now logs only at VERBOSE/DEBUG — INFO and below are silent.
- #34 — Strip debug info from the prebuilt `libAdaptySwiftBridge.a` after dedup, so it no longer ships DWARF entries with build-machine absolute paths (dsymutil warnings on every consumer build). `strip -S` keeps the linkable symbols; framework linking is unaffected.

Also: `capitalize()` → `replaceFirstChar`, `tasks.create` → `tasks.register`, task descriptions added.

Closes #35, #34